### PR TITLE
添加加好友请求和加群请求的验证信息解析

### DIFF
--- a/types.go
+++ b/types.go
@@ -41,6 +41,7 @@ type Update struct {
 	File          *File       `json:"file"`
 	RequestType   string      `json:"request_type"`
 	Flag          string      `json:"flag"`
+	Comment       string      `json:"comment"` // This field is used for Request Event
 	Text          string      `json:"-"` // Message with CQCode
 	Message       *Message    `json:"-"` // Message parsed
 	Sender        *User       `json:"sender"`


### PR DESCRIPTION
Update中缺少Comment字段导致添加好友的验证信息没有被解析，[加好友请求上报数据](https://cqhttp.cc/docs/4.12/#/Post?id=%E4%B8%8A%E6%8A%A5%E6%95%B0%E6%8D%AE9)
